### PR TITLE
Cleanup mutation json

### DIFF
--- a/sly_YEETSKILLRUST.json
+++ b/sly_YEETSKILLRUST.json
@@ -10,7 +10,7 @@
     "starting_trait": true,
     "purifiable": false,
     "valid": false,
-    "cancels": [ "FORGETFUL" ]
+    "cancels": [ "FORGETFUL", "GOODMEMORY" ]
 }
 
 ]

--- a/sly_YEETSKILLRUST.json
+++ b/sly_YEETSKILLRUST.json
@@ -10,6 +10,7 @@
     "starting_trait": true,
     "purifiable": false,
     "valid": false,
+    "types": [ "MEMORY" ],
     "cancels": [ "FORGETFUL", "GOODMEMORY" ]
 }
 

--- a/sly_YEETSKILLRUST.json
+++ b/sly_YEETSKILLRUST.json
@@ -1,17 +1,22 @@
 [
-
-{
-"type": "mutation",
-"id": "SLY_YEETRUST",
-    "name": { "str": "Rustproof Skills" },
+  {
+    "type": "mutation",
+    "id": "SLY_YEETRUST",
+    "name": {
+      "str": "Rustproof Skills"
+    },
     "points": 0,
     "description": "Your mind clamps down on things you've learned more stubbornly than a bulldog with a severed leg.  It'll  be a long, long time before your hard-earned skills begin to erode.",
     "skill_rust_multiplier": 0,
     "starting_trait": true,
     "purifiable": false,
     "valid": false,
-    "types": [ "MEMORY" ],
-    "cancels": [ "FORGETFUL", "GOODMEMORY" ]
-}
-
+    "types": [
+      "MEMORY"
+    ],
+    "cancels": [
+      "FORGETFUL",
+      "GOODMEMORY"
+    ]
+  }
 ]


### PR DESCRIPTION
This PR contains three suggestions to merge:
 - Add `GOODMEMORY` to the cancelled traits. This prevents a player from taking Good Memory along with this trait, which would cause a conflict since both traits make use of `skill_rust_multiplier`.
 - Add this mutation to the `MEMORY` type. This just lumps it in with Good Memory and Forgetful so that it's easier to find the trait in debug.
 - Ran json file through `jq` to pretty print it.